### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ A simple, fast image hosting application
 
 This is a sample project of spring-boot in fact %>_<%
 
-###DEMO
+### DEMO
 http://hime.io/
 
-###Environment
+### Environment
 Java 1.8
 
-###Build from github
-####Environment
+### Build from github
+#### Environment
 1. Java 1.8
 2. Maven 3
 
-####Commands
+#### Commands
 ```
 git clone https://github.com/chocotan/lolibox.git
 cd lolibox
@@ -26,6 +26,6 @@ mvn clean package
 ./lolibox-server/target/lolibox-server-x.y.z-SNAPSHOT.jar
 ```
 
-####Screenshots
+#### Screenshots
 
 ![抓图162.png](http://c.hime.io/images/la.png)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
